### PR TITLE
feat: add AWS DynamoDB service with sample usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,20 @@ If jq not installed: `sudo apt  install jq`
 
 ## Trying AWS S3 service on Localstack
 
-Enable S3 on Localstack is very easy, [this documentation](./docs/s3.md) show how to do this.
+Enable S3 on Localstack is very easy, [this AWS S3 documentation](./docs/s3.md) show how to do this.
 
 Try execute all commands and you will:
  - [x] create a bucket
  - [x] add a object on created bucket
  - [x] lis buckets and it's contents
  - [x] create a signed url and access via curl
+
+## Trying AWS DynamoDB service on Localstack
+
+Enable DynamoDB on Localstack is very simple too, [this AWS DynamoDB documentation](./docs/dynamo-db.md) show how to do this.
+
+Try execute all commands and you will:
+ - [x] create a table
+ - [x] add items on created bucket
+ - [x] list tables and it's contents
+ - [x] query/filter items on table

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       # - DEBUG=${DEBUG:-0}
       DEBUG: '1'
-      SERVICES: 'sqs,s3'
+      SERVICES: 'sqs,s3,dynamodb'
       AWS_ACCESS_KEY_ID: 'AKIAIOSFODNN7EXAMPLE'
       AWS_SECRET_ACCESS_KEY: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
       AWS_DEFAULT_REGION: 'us-east-1'

--- a/docs/dynamo-db.md
+++ b/docs/dynamo-db.md
@@ -1,0 +1,127 @@
+# Adding DynamoDB feature
+
+On [docker-compose file](../docker-compose.yml), change `SERVICES: 'sqs'` to `SERVICES: 'sqs,s3,dynamodb'` adding AWS S3 service.
+
+## Useful commands
+
+### Create a table
+
+``` bash
+aws --endpoint-url=http://localhost:4566 --region us-east-1 dynamodb create-table --table-name localstack --key-schema AttributeName=id,KeyType=HASH --attribute-definitions AttributeName=id,AttributeType=S --billing-mode PAY_PER_REQUEST | jq
+```
+
+Expected result:
+``` json
+{
+    "TableDescription": {
+        "AttributeDefinitions": [
+            {
+                "AttributeName": "id",
+                "AttributeType": "S"
+            }
+        ],
+        "TableName": "localstack",
+        "KeySchema": [
+            {
+                "AttributeName": "id",
+                "KeyType": "HASH"
+            }
+        ],
+        "TableStatus": "ACTIVE",
+        "CreationDateTime": 1729453051.354,
+        "ProvisionedThroughput": {
+            "LastIncreaseDateTime": 0.0,
+            "LastDecreaseDateTime": 0.0,
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 0,
+            "WriteCapacityUnits": 0
+        },
+        "TableSizeBytes": 0,
+        "ItemCount": 0,
+        "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/localstack",
+        "TableId": "2fedc682-4b5c-46fa-a1c6-d078b8379756",
+        "BillingModeSummary": {
+            "BillingMode": "PAY_PER_REQUEST",
+            "LastUpdateToPayPerRequestDateTime": 1729453051.354
+        }
+    }
+}
+```
+
+### List a table
+
+``` bash
+aws --endpoint-url=http://localhost:4566 --region us-east-1 dynamodb list-tables | jq
+```
+
+Expected result:
+``` json
+{
+    "TableNames": [
+        "localstack"
+    ]
+}
+```
+
+### Put some items on table
+
+``` bash
+aws --endpoint-url=http://localhost:4566 --region us-east-1 dynamodb put-item --table-name localstack --item '{"id":{"S":"foo"}}'
+
+aws --endpoint-url=http://localhost:4566 --region us-east-1 dynamodb put-item --table-name localstack --item '{"id":{"S":"bar"}}'
+```
+
+### Describe a table
+
+``` bash
+aws --endpoint-url=http://localhost:4566 --region us-east-1 dynamodb describe-table --table-name localstack --query 'Table.ItemCount'
+```
+
+Expected result:
+``` bash
+2
+```
+
+### Scan a table
+
+``` bash
+aws --endpoint-url=http://localhost:4566 --region us-east-1 dynamodb scan --table-name localstack | jq
+```
+
+Expected result:
+``` json
+{
+    "Items": [
+        {
+            "id": {
+                "S": "bar"
+            }
+        },
+        {
+            "id": {
+                "S": "foo"
+            }
+        }
+    ],
+    "Count": 2,
+    "ScannedCount": 2,
+    "ConsumedCapacity": null
+}
+```
+
+### Query a table
+
+``` bash
+aws --endpoint-url=http://localhost:4566 --region us-east-1 dynamodb get-item --table-name localstack --key '{"id": {"S": "bar"}}' | jq
+```
+
+Expected result:
+``` json
+{
+    "Item": {
+        "id": {
+            "S": "bar"
+        }
+    }
+}
+```

--- a/docs/init.md
+++ b/docs/init.md
@@ -36,7 +36,7 @@ A summary about  this script is:
 
 To check all created queues try:
 ``` bash
-aws --endpoint-url=http://localhost:4566 --region us-east-1 sqs list-queues
+aws --endpoint-url=http://localhost:4566 --region us-east-1 sqs list-queues | jq
 ```
 
 Expected result is something like this:

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -20,7 +20,7 @@ Expected result:
 ### List buckets
 
 ``` bash
-aws --endpoint-url=http://localhost:4566 --region us-east-1 s3api list-buckets
+aws --endpoint-url=http://localhost:4566 --region us-east-1 s3api list-buckets | jq
 ```
 
 Expected result:
@@ -42,7 +42,7 @@ Expected result:
 ### Put object on buckets
 
 ``` bash
-aws --endpoint-url=http://localhost:4566 --region us-east-1 s3api put-object --bucket localstack-bucket --key env-settings --body env-settings
+aws --endpoint-url=http://localhost:4566 --region us-east-1 s3api put-object --bucket localstack-bucket --key env-settings --body env-settings | jq
 ```
 
 Expected result:
@@ -56,7 +56,7 @@ Expected result:
 ### List object on a bucket
 
 ``` bash
-aws --endpoint-url=http://localhost:4566 --region us-east-1 s3api list-objects --bucket localstack-bucket
+aws --endpoint-url=http://localhost:4566 --region us-east-1 s3api list-objects --bucket localstack-bucket | jq
 ```
 
 Expected result:
@@ -70,7 +70,7 @@ Expected result:
 ### Generate a pre-signed URL for S3 object
 
 ``` bash
-aws --endpoint-url=http://localhost:4566 --region us-east-1 s3 presign s3://localstack-bucket/env-settings
+aws --endpoint-url=http://localhost:4566 --region us-east-1 s3 presign s3://localstack-bucket/env-settings | jq
 ```
 
 Expected result:


### PR DESCRIPTION
# Add AWS DynamoDB service with sample usage

This PR elable AWS DynamoDB service on Localstack and try this service actions:

- [x] create a table
- [x] add a items on created table
- [x] list tables and it's items
- [x] query/filter table items
