### PR TITLE
feat: add AWS Route 53 service with sample usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,12 @@ Try execute all commands and you will:
  - [x] create KMS key
  - [x] encrypt data with created key
  - [x] decrypt data
+
+## Trying AWS Route 53 service on Localstack
+
+To enable Route 53 on Localstack, read [this AWS Route 53 documentation](./docs/route-53.md).
+
+Try execute all commands and you will:
+ - [x] create a hosted zone
+ - [x] Change resource record sets
+ - [x] query DNS record

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,13 @@ services:
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
+      - "127.0.0.1:53:53"                # Expose DNS server to host
+      - "127.0.0.1:53:53/udp"            # Expose DNS server to host
     environment:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       # - DEBUG=${DEBUG:-0}
       DEBUG: '1'
-      SERVICES: 'sqs,s3,dynamodb,kms'
+      SERVICES: 'sqs,s3,dynamodb,kms,route53'
       AWS_ACCESS_KEY_ID: 'AKIAIOSFODNN7EXAMPLE'
       AWS_SECRET_ACCESS_KEY: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
       AWS_DEFAULT_REGION: 'us-east-1'

--- a/docs/kms-md
+++ b/docs/kms-md
@@ -53,12 +53,14 @@ Expected result:
 ### Encrypt data
 
 ``` bash
-aws --endpoint-url=http://localhost:4566 kms encrypt --key-id {YOUR-KEY-ID} --plaintext "some important stuff" --output text --query CiphertextBlob | base64 --decode > my_encrypted_data && cat ./my_encrypted_data && echo ''
+key_id=$(aws --endpoint-url=http://localhost:4566 kms list-keys | jq -r '.Keys[0].KeyId') && echo $key_id
+
+aws --endpoint-url=http://localhost:4566 kms encrypt --key-id $key_id --plaintext "some important stuff" --output text --query CiphertextBlob | base64 --decode > my_encrypted_data && cat ./my_encrypted_data && echo ''
 ```
 
 Expected result:
 ``` text
-�y�N722c-310e-4b95-b567-a9e797299f42�C�pV��m��4{�=4����>�Bж�)՗�{Lk�)A녁�ǝ��o��
+bc2592a3-f9f8-43d5-8c70-b4641293a06d��x�4H�//�  �fZ$�H��w�F�M$  �'D}3���<WH/��/_�D#������0ī6
 ```
 
 ### Decrypt data

--- a/docs/route-53.md
+++ b/docs/route-53.md
@@ -1,0 +1,64 @@
+# Adding KMS feature
+
+On [docker-compose file](../docker-compose.yml), change `SERVICES: 'sqs,s3,dynamodb,kms'` to `SERVICES: 'sqs,s3,dynamodb,kms,route53'` adding AWS KMS service.
+
+Also add this two ports:
+``` bash
+    ports:
+      - "127.0.0.1:53:53"                # Expose DNS server to host
+      - "127.0.0.1:53:53/udp"            # Expose DNS server to host
+```
+
+## Useful commands
+
+### Create a hosted zone
+
+``` bash
+zone_id=$(aws --endpoint-url=http://localhost:4566 route53 create-hosted-zone --name mmcwebsolutions.io --caller-reference r1 | jq -r '.HostedZone.Id') && echo $zone_id
+```
+
+Expected result:
+``` text
+/hostedzone/LYR7YG78QNK44E6
+```
+
+### Change resource record sets
+
+``` bash
+aws --endpoint-url=http://localhost:4566 route53 change-resource-record-sets --hosted-zone-id $zone_id --change-batch 'Changes=[{Action=CREATE,ResourceRecordSet={Name=marco.mmcwebsolutions.io,Type=A,ResourceRecords=[{Value=1.2.3.4}]}}]' | jq
+```
+
+Expected result:
+``` json
+{
+    "ChangeInfo": {
+        "Id": "/change/C2682N5HXP0BZ4",
+        "Status": "INSYNC",
+        "SubmittedAt": "2010-09-10T01:36:41.958000Z"
+    }
+}
+```
+
+### Query DNS record
+
+``` bash
+ dig @localhost marco.mmcwebsolutions.io
+```
+
+Expected result:
+``` text
+; <<>> DiG 9.18.28-0ubuntu0.20.04.1-Ubuntu <<>> @localhost marco.mmcwebsolutions.io
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 49074
+;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
+
+;; QUESTION SECTION:
+;marco.mmcwebsolutions.io.      IN      A
+
+;; Query time: 74 msec
+;; SERVER: 127.0.0.1#53(localhost) (UDP)
+;; WHEN: Sun Oct 20 17:37:52 -03 2024
+;; MSG SIZE  rcvd: 42
+```


### PR DESCRIPTION
# Add AWS Route 53 service on Localstack

Enable Route 53 on Localstack withg some commands to use it:

 - [x] create a hosted zone
 - [x] Change resource record sets
 - [x] query DNS record
